### PR TITLE
react api cleanup

### DIFF
--- a/src/oncurrent/zeno/client.cljc
+++ b/src/oncurrent/zeno/client.cljc
@@ -44,6 +44,10 @@
      (set-state! zc path arg cb)
      ch)))
 
+(defn get-subscription-info [zc state-sub-name]
+  (when-let [info (-> zc :*state-sub-name->info deref (get state-sub-name))]
+    (select-keys info [:state :resolution-map])))
+
 (defn subscribe-to-state!
   "Creates a Zeno subscription. When the state or events referred to by any
    of the paths in the `sub-map` changes, `update-fn` is called.

--- a/src/oncurrent/zeno/client/react.cljc
+++ b/src/oncurrent/zeno/client/react.cljc
@@ -6,6 +6,7 @@
    [clojure.core.async :as ca]
    [clojure.string :as str]
    [deercreeklabs.async-utils :as au]
+   [oncurrent.zeno.client :as zeno.client]
    [oncurrent.zeno.client.macro-impl :as macro-impl]
    [oncurrent.zeno.utils :as u]
    [taoensso.timbre :as log]
@@ -132,28 +133,29 @@
                                      :resolution-map resolution-map}
                                update-fn (fn [new-state]
                                            (render! (u/current-time-ms)))]
-                           (u/subscribe-to-state! zc component-name sub-map
-                                                  update-fn opts))
+                           (zeno.client/subscribe-to-state!
+                             zc component-name sub-map update-fn opts))
             cleanup-effect (fn []
-                             #(u/unsubscribe-from-state! zc component-name))
-            sub-info (u/get-subscription-info zc component-name)]
+                             #(zeno.client/unsubscribe-from-state!
+                                zc component-name))
+            sub-info (zeno.client/get-subscription-info zc component-name)]
         (use-effect cleanup-effect #js [])
         (if (not sub-info)
           (subscribe*!)
           (if (= resolution-map (:resolution-map sub-info))
             (:state sub-info)
             (do
-              (u/unsubscribe-from-state! zc component-name)
+              (zeno.client/unsubscribe-from-state! zc component-name)
               (subscribe*!))))))))
 
 (defn use-topic-subscription
   "React hook for Zeno topic subscriptions."
-  ([zc scope topic-name cb]
+  ([zc topic-name cb]
    #?(:cljs
-      (use-effect #(u/subscribe-to-topic! zc scope topic-name cb))))
-  ([zc scope topic-name cb dependencies]
+      (use-effect #(zeno.client/subscribe-to-topic! zc topic-name cb))))
+  ([zc topic-name cb dependencies]
    #?(:cljs
-      (use-effect #(u/subscribe-to-topic! zc scope topic-name cb)
+      (use-effect #(zeno.client/subscribe-to-topic! zc topic-name cb)
                   dependencies))))
 
 ;;;;;;;;;;;;;;;;;;;; Macro runtime helpers ;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
These are the changes I was thinking in my Slack message. It doesn't actually work though because there is now a cyclic dependency:
```
[ /oncurrent/zeno/client ]->/oncurrent/zeno/client/react->/oncurrent/zeno/client/state_subscriptions->/oncurrent/zeno/client/impl->[ /oncurrent/zeno/client ]
```

The issue is without these changes there are issues since `u/subscribe-to-state!` doesn't exist since there is no zeno-client protocol defined in utils (as there is in Vivo). Nor was there a `get-subscription-info` implemented anywhere at all.

Do these line up with your "Server Side" stuff that should be done by the 15th and perhaps just yet unfinished since you haven't turned your attention here yet?