### PR TITLE
magic-token renames, indenting to match standard

### DIFF
--- a/src/com/oncurrent/zeno/authenticators/magic_token/client.cljc
+++ b/src/com/oncurrent/zeno/authenticators/magic_token/client.cljc
@@ -12,75 +12,75 @@
    [com.oncurrent.zeno.utils :as u]
    [taoensso.timbre :as log]))
 
-(defn <send-magic-token!
+(defn <request-magic-token!
   "Returns a boolean success value."
   [zc {:keys [identifier mins-valid number-of-uses extra-info extra-info-schema]
-       :as send-magic-token-info}]
+       :as request-magic-token-info}]
   (au/go
-    (when-not (string? identifier)
-      (throw (ex-info (str "`identifier` must be a string. Got `"
-                           (or identifier "nil") "`.")
-                      (u/sym-map identifier))))
-    (when (and extra-info (not extra-info-schema))
-      (throw (ex-info "extra-info was provided with no extra-info-schema."
-                      (u/sym-map extra-info))))
-    (when (and extra-info-schema (not (l/schema? extra-info-schema)))
-      (throw (ex-info "extra-info-schema was provided but is not a Lancaster schema."
-                      (u/sym-map extra-info-schema))))
-    (let [send-magic-token-info*
-          (if-not (and extra-info extra-info-schema)
-            send-magic-token-info
-            (assoc send-magic-token-info :serialized-extra-info
-                   (au/<? (storage/<value->serialized-value
-                            (:storage zc) extra-info-schema extra-info))))
-          arg {:authenticator-name shared/authenticator-name
-               :return-value-schema l/boolean-schema
-               :update-info-schema shared/send-magic-token-info-schema
-               :update-info send-magic-token-info*
-               :update-type :send-magic-token
-               :zc zc}]
-      (au/<? (za/<client-update-authenticator-state arg))
-      true)))
+   (when-not (string? identifier)
+     (throw (ex-info (str "`identifier` must be a string. Got `"
+                          (or identifier "nil") "`.")
+                     (u/sym-map identifier))))
+   (when (and extra-info (not extra-info-schema))
+     (throw (ex-info "extra-info was provided with no extra-info-schema."
+                     (u/sym-map extra-info))))
+   (when (and extra-info-schema (not (l/schema? extra-info-schema)))
+     (throw (ex-info "extra-info-schema was provided but is not a Lancaster schema."
+                     (u/sym-map extra-info-schema))))
+   (let [request-magic-token-info*
+         (if-not (and extra-info extra-info-schema)
+           request-magic-token-info
+           (assoc request-magic-token-info :serialized-extra-info
+                  (au/<? (storage/<value->serialized-value
+                          (:storage zc) extra-info-schema extra-info))))
+         arg {:authenticator-name shared/authenticator-name
+              :return-value-schema l/boolean-schema
+              :update-info-schema shared/request-magic-token-info-schema
+              :update-info request-magic-token-info*
+              :update-type :request-magic-token
+              :zc zc}]
+     (au/<? (za/<client-update-authenticator-state arg))
+     true)))
 
 (defn <redeem-magic-token!
   ([zc token]
    (<redeem-magic-token! zc token nil))
   ([zc token extra-info-schema]
    (au/go
-     (when-not (string? token)
-       (throw (ex-info (str "`token` must be a string. Got `"
-                            (or token "nil") "`.")
-                       (u/sym-map token))))
-     (when (and extra-info-schema (not (l/schema? extra-info-schema)))
-       (throw (ex-info "extra-info-schema was provided but is not a Lancaster schema."
-                       (u/sym-map extra-info-schema))))
-     (let [arg {:authenticator-name shared/authenticator-name
-                :login-info token
-                :login-info-schema shared/token-schema
-                :zc zc}
-           ret (au/<? (za/<client-log-in arg))
-           ;; Note that the plubming can return extra-info which has a naming
-           ;; collision with this plugin's extra-info. In this case we use the
-           ;; plumbing's extra-info to return the token-info which includes
-           ;; our plugin's serialized-extra-info, so we perform a rename in the
-           ;; below destructure.
-           {session-info :session-info token-info :extra-info} ret
-           {:keys [serialized-extra-info]} token-info]
-       (if session-info
-         {:session-info session-info
-          :token-info
-          (assoc token-info :extra-info
-                 (when serialized-extra-info
-                   (au/<? (common/<serialized-value->value
-                            {:<request-schema (za/make-schema-requester
-                                                (:talk2-client zc))
-                             :reader-schema extra-info-schema
-                             :serialized-value serialized-extra-info
-                             :storage (:storage zc)}))))}
-         false)))))
+    (when-not (string? token)
+      (throw (ex-info (str "`token` must be a string. Got `"
+                           (or token "nil") "`.")
+                      (u/sym-map token))))
+    (when (and extra-info-schema (not (l/schema? extra-info-schema)))
+      (throw (ex-info "extra-info-schema was provided but is not a Lancaster schema."
+                      (u/sym-map extra-info-schema))))
+    (let [arg {:authenticator-name shared/authenticator-name
+               :login-info token
+               :login-info-schema shared/token-schema
+               :zc zc}
+          ret (au/<? (za/<client-log-in arg))
+          ;; Note that the plubming can return extra-info which has a naming
+          ;; collision with this plugin's extra-info. In this case we use the
+          ;; plumbing's extra-info to return the token-info which includes
+          ;; our plugin's serialized-extra-info, so we perform a rename in the
+          ;; below destructure.
+          {session-info :session-info token-info :extra-info} ret
+          {:keys [serialized-extra-info]} token-info]
+      (if session-info
+        {:session-info session-info
+         :token-info
+         (assoc token-info :extra-info
+                (when serialized-extra-info
+                  (au/<? (common/<serialized-value->value
+                          {:<request-schema (za/make-schema-requester
+                                             (:talk2-client zc))
+                           :reader-schema extra-info-schema
+                           :serialized-value serialized-extra-info
+                           :storage (:storage zc)}))))}
+        false)))))
 
 (defn <create-actor!
-   "Returns the actor-id of the created actor."
+  "Returns the actor-id of the created actor."
   ([zc identifier]
    (<create-actor! zc identifier nil))
   ([zc identifier actor-id]
@@ -99,10 +99,10 @@
 (defn <add-identifier!
   "Works on current actor. Must be logged in. Returns a boolean success value."
   [zc identifier]
-   (when-not (string? identifier)
-     (throw (ex-info (str "`identifier` must be a string. Got `"
-                          (or identifier "nil") "`.")
-                     (u/sym-map identifier))))
+  (when-not (string? identifier)
+    (throw (ex-info (str "`identifier` must be a string. Got `"
+                         (or identifier "nil") "`.")
+                    (u/sym-map identifier))))
   (when-not (zc/logged-in? zc)
     (throw (ex-info "Must be logged in to call `<add-identifier!`"
                     (u/sym-map identifier))))
@@ -137,5 +137,5 @@
 
 (defn <resume-session! [zc session-token]
   (au/go
-    (let [ret (au/<? (za/<client-resume-session zc session-token))]
-      (or ret false))))
+   (let [ret (au/<? (za/<client-resume-session zc session-token))]
+     (or ret false))))

--- a/src/com/oncurrent/zeno/authenticators/magic_token/shared.cljc
+++ b/src/com/oncurrent/zeno/authenticators/magic_token/shared.cljc
@@ -12,7 +12,7 @@
   [:bytes l/bytes-schema]
   [:fp schemas/fingerprint-schema])
 
-(l/def-record-schema send-magic-token-info-schema
+(l/def-record-schema request-magic-token-info-schema
   [:identifier identifier-schema]
   [:mins-valid l/int-schema]
   [:number-of-uses l/int-schema]

--- a/test/integration/test_server.clj
+++ b/test/integration/test_server.clj
@@ -29,10 +29,10 @@
   [mins-valid number-of-uses]
   mt-auth/IMagicTokenApplicationServer
   (get-extra-info-schema [this] l/string-schema)
-  (<send-magic-token! [this token token-info]
+  (<handle-request-magic-token! [this token token-info]
     (au/go
       (spit (:extra-info token-info) (str token "\n") :append true)))
-  (<do-action! [this token-info]
+  (<handle-redeem-magic-token! [this _token token-info]
     (au/go
       (spit (:extra-info token-info) "did-action!\n" :append true))))
 


### PR DESCRIPTION
`send-magic-token` -> `request-magic-token`
Application server now implements `<handle-request-magic-token!`

`<do-action!` -> `<handle-redeem-magic-token!`

Also I changed my editor to match the indenting style as discussed https://guide.clojure.style/#one-space-indent.