### PR TITLE
Magic token actor subtlety

### DIFF
--- a/src/com/oncurrent/zeno/authenticators/magic_token/server.clj
+++ b/src/com/oncurrent/zeno/authenticators/magic_token/server.clj
@@ -126,16 +126,15 @@
   [{{:keys [identifier mins-valid number-of-uses] :as info} :update-info
     {:keys [default-mins-valid default-number-of-uses]} :mtas
     :keys [actor-id authenticator-storage]}]
-  (au/go
-   (-> info
-       (assoc :actor-id actor-id)
-       (assoc :expiration-ms (number-of-mins->epoch-ms
-                              (or mins-valid
-                                  default-mins-valid
-                                  default-mins-valid*)))
-       (assoc :remaining-uses (or number-of-uses
-                                  default-number-of-uses
-                                  default-number-of-uses*)))))
+  (-> info
+      (assoc :actor-id actor-id)
+      (assoc :expiration-ms (number-of-mins->epoch-ms
+                             (or mins-valid
+                                 default-mins-valid
+                                 default-mins-valid*)))
+      (assoc :remaining-uses (or number-of-uses
+                                 default-number-of-uses
+                                 default-number-of-uses*))))
 
 (defn <add-identifier* [{:keys [authenticator-storage actor-id identifier]}]
   (au/go
@@ -162,8 +161,9 @@
          stored-actor-id (or (au/<? (storage/<get authenticator-storage
                                                   (identifier-key identifier)
                                                   schemas/actor-id-schema))
-                             (<add-identifier* (u/sym-map authenticator-storage
-                                                          identifier)))
+                             (au/<? (<add-identifier*
+                                     (u/sym-map authenticator-storage
+                                                identifier))))
          token-info (request-magic-token-info->magic-token-info
                      (assoc arg :actor-id stored-actor-id))]
      (au/<? (storage/<swap! authenticator-storage

--- a/src/com/oncurrent/zeno/authenticators/magic_token/server.clj
+++ b/src/com/oncurrent/zeno/authenticators/magic_token/server.clj
@@ -122,15 +122,13 @@
 
 (defmulti <update-authenticator-state!* :update-type)
 
-(defn <request-magic-token-info->magic-token-info
+(defn request-magic-token-info->magic-token-info
   [{{:keys [identifier mins-valid number-of-uses] :as info} :update-info
     {:keys [default-mins-valid default-number-of-uses]} :mtas
-    :keys [authenticator-storage]}]
+    :keys [actor-id authenticator-storage]}]
   (au/go
    (-> info
-       (assoc :actor-id (au/<? (storage/<get authenticator-storage
-                                             (identifier-key identifier)
-                                             schemas/actor-id-schema)))
+       (assoc :actor-id actor-id)
        (assoc :expiration-ms (number-of-mins->epoch-ms
                               (or mins-valid
                                   default-mins-valid
@@ -139,12 +137,35 @@
                                   default-number-of-uses
                                   default-number-of-uses*)))))
 
-(defmethod <update-authenticator-state!* :request-magic-token
-  [{:keys [authenticator-storage update-info mtas] :as arg}]
+(defn <add-identifier* [{:keys [authenticator-storage actor-id identifier]
+                         :or {actor-id (u/compact-random-uuid)}}]
   (au/go
-   (let [token (generate-token)
+   (try
+    (au/<? (storage/<add! authenticator-storage
+                          (identifier-key identifier)
+                          schemas/actor-id-schema
+                          actor-id))
+    actor-id
+    (catch ExceptionInfo e
+      (if (= :key-exists (some-> e ex-data :type))
+        (throw (ex-info
+                (str "identifier `" identifier "` already exists.")
+                (u/sym-map actor-id identifier)))
+        (throw e))))))
+
+(defmethod <update-authenticator-state!* :request-magic-token
+  [{:keys [actor-id authenticator-storage update-info mtas] :as arg}]
+  (au/go
+   (let [{:keys [identifier]} update-info
+         token (generate-token)
          hashed-token (encrypt-const-salt token)
-         token-info (au/<? (<request-magic-token-info->magic-token-info arg))]
+         stored-actor-id (or (au/<? (storage/<get authenticator-storage
+                                                  (identifier-key identifier)
+                                                  schemas/actor-id-schema))
+                             (<add-identifier* (u/sym-map authenticator-storage
+                                                          identifier)))
+         token-info (request-magic-token-info->magic-token-info
+                     (assoc arg :actor-id stored-actor-id))]
      (au/<? (storage/<swap! authenticator-storage
                             (hashed-token-key hashed-token)
                             shared/magic-token-info-schema
@@ -158,28 +179,12 @@
                                                   token-info arg))})))
      true)))
 
-(defn <add-identifier* [{:keys [authenticator-storage actor-id identifier]}]
-  (au/go
-   (try
-    (au/<? (storage/<add! authenticator-storage
-                          (identifier-key identifier)
-                          schemas/actor-id-schema
-                          actor-id))
-    (catch ExceptionInfo e
-      (if (= :key-exists (some-> e ex-data :type))
-        (throw (ex-info
-                (str "identifier `" identifier "` already exists.")
-                (u/sym-map actor-id identifier)))
-        (throw e))))))
-
 (defmethod <update-authenticator-state!* :create-actor
   [{:keys [authenticator-storage update-info]}]
   (au/go
-   (let [{:keys [actor-id identifier]
-          :or {actor-id (u/compact-random-uuid)}} update-info]
+   (let [{:keys [actor-id identifier]} update-info]
      (au/<? (<add-identifier* (u/sym-map authenticator-storage actor-id
-                                         identifier)))
-     actor-id)))
+                                         identifier))))))
 
 (defmethod <update-authenticator-state!* :add-identifier
   [{:keys [authenticator-storage actor-id update-info]}]


### PR DESCRIPTION
This allows one to request a magic token for an identifier for which no actor has yet been created. It will create a new actor automatically. This came up because in the application I realized there are 6 cases.

1. The requester has an actor-id and requests a token for themselves.
2. The requester has an actor-id and requests a token for someone else who also has an actor-id (like sending a notification email of a new proposal on an existing deal).
3. The requester has an actor-id and requests a token for someone else who does not have an actor-id (like sending a new deal to someone who hasn't used Oncurrent before).
4. The requestor does not have an actor id and requests a token for themselves as part of a passwordless account creation process.
5. The requestor does not have an actor id and requests a token for someone else who has one (don't have a use case)
6. The requestor does not have an actor id and requests a token for someone else who also doesn't have one (don't have a use case).

This PR handles cases 3 and 4 which were not possible before. The application developer can accomplish anything they want with all cases if they also remember that their handlers receive the actor id's for both parties. The call signature for a request/redeem handler is [mtas arg]. Arg contains actor-id and token-info (among other things) and token-info also has an actor-id inside. The first actor-id is the one of the requester and the actor-id in token-info is the one for the receiver. Up until now I hadn't considered they would be different, but they may be as described above.