### PR TITLE
Magic token params

### DIFF
--- a/src/com/oncurrent/zeno/authenticators/magic_token/server.clj
+++ b/src/com/oncurrent/zeno/authenticators/magic_token/server.clj
@@ -137,7 +137,8 @@
                                  default-mins-valid*)))
       (assoc :remaining-uses (or number-of-uses
                                  default-number-of-uses
-                                 default-number-of-uses*))))
+                                 default-number-of-uses*))
+      (dissoc :serialized-params)))
 
 (defn <add-identifier* [{:keys [authenticator-storage actor-id identifier]}]
   (au/go

--- a/src/com/oncurrent/zeno/authenticators/magic_token/server.clj
+++ b/src/com/oncurrent/zeno/authenticators/magic_token/server.clj
@@ -70,6 +70,7 @@
 ;; corresponding keys in the record that implements this protocol.
 (defprotocol IMagicTokenApplicationServer
   (get-extra-info-schema [this])
+  (get-params-schema [this])
   (<handle-request-magic-token! [this arg])
   (<handle-redeem-magic-token! [this arg]))
 
@@ -77,13 +78,15 @@
   [{:keys [serialized-extra-info] :as token-info}
    {:keys [authenticator-storage mtas] :as arg}]
   (au/go
-   (assoc token-info :extra-info
-          (when serialized-extra-info
-            (au/<? (common/<serialized-value->value
-                    {:<request-schema (su/make-schema-requester arg)
-                     :reader-schema (get-extra-info-schema mtas)
-                     :serialized-value serialized-extra-info
-                     :storage authenticator-storage}))))))
+   (-> token-info
+       (assoc :extra-info
+              (when serialized-extra-info
+                (au/<? (common/<serialized-value->value
+                        {:<request-schema (su/make-schema-requester arg)
+                         :reader-schema (get-extra-info-schema mtas)
+                         :serialized-value serialized-extra-info
+                         :storage authenticator-storage}))))
+       (dissoc :serialized-extra-info))))
 
 (defn <log-in!* [{token :login-info
                   :keys [login-lifetime-mins authenticator-storage mtas]
@@ -125,7 +128,7 @@
 (defn request-magic-token-info->magic-token-info
   [{{:keys [identifier mins-valid number-of-uses] :as info} :update-info
     {:keys [default-mins-valid default-number-of-uses]} :mtas
-    :keys [actor-id authenticator-storage]}]
+    :keys [actor-id]}]
   (-> info
       (assoc :actor-id actor-id)
       (assoc :expiration-ms (number-of-mins->epoch-ms
@@ -155,7 +158,7 @@
 (defmethod <update-authenticator-state!* :request-magic-token
   [{:keys [actor-id authenticator-storage update-info mtas] :as arg}]
   (au/go
-   (let [{:keys [identifier]} update-info
+   (let [{:keys [identifier serialized-params]} update-info
          token (generate-token)
          hashed-token (encrypt-const-salt token)
          stored-actor-id (or (au/<? (storage/<get authenticator-storage
@@ -165,7 +168,8 @@
                                      (u/sym-map authenticator-storage
                                                 identifier))))
          token-info (request-magic-token-info->magic-token-info
-                     (assoc arg :actor-id stored-actor-id))]
+                     (assoc (u/sym-map update-info mtas)
+                            :actor-id stored-actor-id))]
      (au/<? (storage/<swap! authenticator-storage
                             (hashed-token-key hashed-token)
                             shared/magic-token-info-schema
@@ -174,9 +178,17 @@
                                 (throw (ex-info "Token already in use." {})))
                               token-info)))
      (au/<? (<handle-request-magic-token!
-             mtas (merge arg {:token token
-                              :token-info (au/<? (<with-deserialized-extra-info
-                                                  token-info arg))})))
+             mtas (merge arg
+                         {:token token
+                          :token-info (au/<? (<with-deserialized-extra-info
+                                              token-info arg))
+                          :params (au/<?
+                                   (common/<serialized-value->value
+                                    {:<request-schema (su/make-schema-requester
+                                                       arg)
+                                     :reader-schema (get-params-schema mtas)
+                                     :serialized-value serialized-params
+                                     :storage authenticator-storage}))})))
      true)))
 
 (defmethod <update-authenticator-state!* :create-actor

--- a/src/com/oncurrent/zeno/authenticators/magic_token/shared.cljc
+++ b/src/com/oncurrent/zeno/authenticators/magic_token/shared.cljc
@@ -16,7 +16,8 @@
   [:identifier identifier-schema]
   [:mins-valid l/int-schema]
   [:number-of-uses l/int-schema]
-  [:serialized-extra-info serialized-value-schema])
+  [:serialized-extra-info serialized-value-schema]
+  [:serialized-params serialized-value-schema])
 
 (l/def-record-schema magic-token-info-schema
   [:actor-id schemas/actor-id-schema]

--- a/test/integration/test_server.clj
+++ b/test/integration/test_server.clj
@@ -31,12 +31,17 @@
   [mins-valid number-of-uses]
   mt-auth/IMagicTokenApplicationServer
   (get-extra-info-schema [this] l/string-schema)
-  (<handle-request-magic-token! [this {:keys [token token-info]}]
+  (get-params-schema [this] l/string-schema)
+  (<handle-request-magic-token! [this arg]
     (au/go
-      (spit (:extra-info token-info) (str token "\n") :append true)))
+     (spit (-> arg :token-info :extra-info)
+           (prn-str (select-keys arg [:actor-id :token :token-info :params]))
+           :append true)))
   (<handle-redeem-magic-token! [this {:keys [token-info]}]
     (au/go
-      (spit (:extra-info token-info) "did-action!\n" :append true))))
+     (spit (:extra-info token-info)
+           (prn-str (select-keys token-info [:actor-id :identifier]))
+           :append true))))
 
 (defn make-mtas
   ([] (make-mtas {}))

--- a/test/integration/test_server.clj
+++ b/test/integration/test_server.clj
@@ -37,10 +37,10 @@
      (spit (-> arg :token-info :extra-info)
            (prn-str (select-keys arg [:actor-id :token :token-info :params]))
            :append true)))
-  (<handle-redeem-magic-token! [this {:keys [token-info]}]
+  (<handle-redeem-magic-token! [this arg]
     (au/go
-     (spit (:extra-info token-info)
-           (prn-str (select-keys token-info [:actor-id :identifier]))
+     (spit (-> arg :token-info :extra-info)
+           (prn-str (select-keys arg [:token :token-info]))
            :append true))))
 
 (defn make-mtas


### PR DESCRIPTION
Changes:
* Add ability for client who calls `<request-magic-token!` to pass parameters to the server side `<handle-request-magic-token!` that are not stored in the token (extra-info is stored). This arose because when you `nudge` a team member you write `email-lines` in the application and they need to get to the server in order to be in the email. I didn't want to store said `email-lines` with the `token-info` because it's wasteful and the redeem side of things won't need them. Hence params.
* Adjusted existing magic-token tests to be a tiny bit more thorough.
* Added test for the differing actor-id PR (#14).
* Added test for the aforementioned params.