### PR TITLE
magic-token track requestor-id

### DIFF
--- a/src/com/oncurrent/zeno/authenticators/magic_token/server.clj
+++ b/src/com/oncurrent/zeno/authenticators/magic_token/server.clj
@@ -128,9 +128,10 @@
 (defn request-magic-token-info->magic-token-info
   [{{:keys [identifier mins-valid number-of-uses] :as info} :update-info
     {:keys [default-mins-valid default-number-of-uses]} :mtas
-    :keys [actor-id]}]
+    :keys [actor-id requestor-id]}]
   (-> info
       (assoc :actor-id actor-id)
+      (assoc :requestor-id requestor-id)
       (assoc :expiration-ms (number-of-mins->epoch-ms
                              (or mins-valid
                                  default-mins-valid
@@ -170,7 +171,8 @@
                                                 identifier))))
          token-info (request-magic-token-info->magic-token-info
                      (assoc (u/sym-map update-info mtas)
-                            :actor-id stored-actor-id))]
+                            :actor-id stored-actor-id
+                            :requestor-id actor-id))]
      (au/<? (storage/<swap! authenticator-storage
                             (hashed-token-key hashed-token)
                             shared/magic-token-info-schema

--- a/src/com/oncurrent/zeno/authenticators/magic_token/shared.cljc
+++ b/src/com/oncurrent/zeno/authenticators/magic_token/shared.cljc
@@ -24,6 +24,7 @@
   [:identifier identifier-schema]
   [:expiration-ms l/long-schema]
   [:remaining-uses l/int-schema]
+  [:requestor-id schemas/actor-id-schema]
   [:serialized-extra-info serialized-value-schema])
 
 (l/def-record-schema create-actor-info-schema

--- a/test/integration/authentication_test.cljc
+++ b/test/integration/authentication_test.cljc
@@ -404,6 +404,7 @@
          ;; Notice this next one, no one was logged in when the request
          ;; happened. It was a request in order to log in.
          (is (= nil (-> request1-handle :actor-id)))
+         (is (= nil (-> redeem1-handle :token-info :requestor-id)))
          (is (= actor1 (-> request1-handle :token-info :actor-id)))
          (is (= actor1 (-> redeem1-handle :token-info :actor-id)))
          (is (= actor1 (-> redeem1-ret :token-info :actor-id)))
@@ -414,6 +415,7 @@
          ;; Notice this next one, actor1 requested a token for actor2, perhaps
          ;; inviting them to use the app.
          (is (= actor1 (-> request2-handle :actor-id)))
+         (is (= actor1 (-> redeem2-handle :token-info :requestor-id)))
          (is (= actor2 (-> redeem2-handle :token-info :actor-id)))
          (is (= actor2 (-> redeem2-ret :token-info :actor-id)))
          (is (= actor2 (-> redeem2-ret :login-session-info :actor-id))))


### PR DESCRIPTION
Having the plugin track the requestor-id which sometimes differs from who the token is supposed to authenticate will avoid a class of bugs where the application would've had to track this in extra-info and if it was wrong would lead to security leaks and confusion.

This information is already available to request handlers but was not persisted anywhere for redeem handlers to use. In the case of the token recipient granting the token requester permissions to edit a deal you want this.