### PR TITLE
authenticator identifiers consistently lower case

### DIFF
--- a/src/com/oncurrent/zeno/authenticators/magic_token/server.clj
+++ b/src/com/oncurrent/zeno/authenticators/magic_token/server.clj
@@ -67,8 +67,6 @@
                 (identifier-key identifier)
                 schemas/actor-id-schema))
 
-(defn <get-token-info-for-token [authenticator-storage token])
-
 (defn <dec-remaining-uses! [authenticator-storage hashed-token]
   (storage/<swap! authenticator-storage
                   (hashed-token-key hashed-token)


### PR DESCRIPTION
While working on the Oncurrent authenticator I noticed we inconsistently lower-cased the identifier so I back ported the fix. Now it's always lower-cased.