### PR TITLE
use correct client ns in react

### DIFF
--- a/src/com/oncurrent/zeno/client/react.cljc
+++ b/src/com/oncurrent/zeno/client/react.cljc
@@ -6,7 +6,7 @@
    [clojure.core.async :as ca]
    [clojure.string :as str]
    [deercreeklabs.async-utils :as au]
-   [com.oncurrent.zeno.client.impl :as client]
+   [com.oncurrent.zeno.client :as client]
    [com.oncurrent.zeno.client.macro-impl :as macro-impl]
    [com.oncurrent.zeno.client.react.impl :as react-impl]
    [com.oncurrent.zeno.utils :as u]


### PR DESCRIPTION
Running bin/watch in Oncurrent/web told me that some functions were missing from the ns required as `client`. Indeed they were, it's because they are in the main client ns not impl. Functions like `unsubscribe-from-state` and `subscribe-to-state`. The tests don't do any worse (some crdt failures and the magic-token tests don't work in cljs and should probably be only clj with the io they use) after this change though I'm not sure this change is covered.