### PR TITLE
add authenticator-name->info to rpcs

### DIFF
--- a/src/com/oncurrent/zeno/server.clj
+++ b/src/com/oncurrent/zeno/server.clj
@@ -218,6 +218,7 @@
 (defn <do-rpc! [{:keys [*conn-id->auth-info
                         *conn-id->sync-session-info
                         *rpc-name-kw->handler
+                        authenticator-name->info
                         conn-id
                         <get-state
                         <set-state!
@@ -252,6 +253,7 @@
                                              (merge {:zeno/branch branch} %))
                               :<update-state! #(<update-state!
                                                 (merge {:zeno/branch branch} %))
+                              :authenticator-name->info authenticator-name->info
                               :arg deser-arg
                               :actor-id actor-id
                               :branch branch


### PR DESCRIPTION
I was expected this to be here as per a previous discussion. This allows RPC's to do things like call a server side functions in the authenticator like <create-actor! which require authenticator-storage to be passed in. The RPC gets the relevant authenticator storage out of authenticator-name->info and then can pass it in.