### PR TITLE
Arrays

### DIFF
--- a/src/com/oncurrent/zeno/crdt/commands.cljc
+++ b/src/com/oncurrent/zeno/crdt/commands.cljc
@@ -83,7 +83,9 @@
                  {:ops #{}
                   :norm-path norm-path}
                  (:children crdt))
-      (get-child-ops-info (get-child-path-info path)))))
+      (-> path
+          (get-child-path-info)
+          (get-child-ops-info)))))
 
 (defmethod get-delete-ops-info :map
   [{:keys [schema] :as arg}]

--- a/src/com/oncurrent/zeno/crdt/commands.cljc
+++ b/src/com/oncurrent/zeno/crdt/commands.cljc
@@ -83,8 +83,7 @@
                  {:ops #{}
                   :norm-path norm-path}
                  (:children crdt))
-      (let [[k & ks] path]
-        (get-child-ops-info (get-child-path-info path))))))
+      (get-child-ops-info (get-child-path-info path)))))
 
 (defmethod get-delete-ops-info :map
   [{:keys [schema] :as arg}]

--- a/src/com/oncurrent/zeno/crdt/common.cljc
+++ b/src/com/oncurrent/zeno/crdt/common.cljc
@@ -199,7 +199,6 @@
                     (u/sym-map op-type norm-path crdt-schema))]
         (cond-> op
           true (dissoc :path)
-          true (assoc :op-path path)
           true (dissoc :value)
           schema (assoc :serialized-value
                         (au/<? (storage/<value->serialized-value
@@ -209,12 +208,10 @@
   [{:keys [storage crdt-schema op] :as arg}]
   (au/go
     (when op
-      (let [{:keys [norm-path op-type op-path serialized-value]} op
+      (let [{:keys [norm-path op-type serialized-value]} op
             schema (get-op-value-schema
                     (u/sym-map op-type norm-path crdt-schema))]
         (cond-> op
-          true (dissoc :op-path)
-          true (assoc :path op-path)
           true (dissoc :serialized-value)
           schema (assoc :value
                         (au/<? (common/<serialized-value->value

--- a/src/com/oncurrent/zeno/schemas.cljc
+++ b/src/com/oncurrent/zeno/schemas.cljc
@@ -79,7 +79,6 @@
   "Depending on the op-type, different fields will be used."
   [:add-id add-id-schema]
   [:norm-path path-schema]
-  [:op-path path-schema]
   [:op-type crdt-op-type-schema]
   [:serialized-value serialized-value-schema]
   [:sys-time-ms timestamp-ms-schema])

--- a/test/unit/crdt_commands_test.cljc
+++ b/test/unit/crdt_commands_test.cljc
@@ -133,9 +133,42 @@
                                            :path []
                                            :schema (:crdt-schema arg)})))))
 
+
+(comment (kaocha.repl/run #'test-crdt-array-set-empty))
+(deftest test-crdt-array-set-empty
+  (let [sys-time-ms (u/str->long "1643061294999")
+        arg {:cmds [{:zeno/arg []
+                     :zeno/op :zeno/set
+                     :zeno/path [:zeno/crdt]}]
+             :crdt-schema (l/array-schema l/string-schema)
+             :sys-time-ms sys-time-ms}
+        {:keys [crdt ops]} (commands/process-cmds arg)
+        expected-value []]
+    (is (= expected-value (crdt/get-value {:crdt crdt
+                                           :path []
+                                           :schema (:crdt-schema arg)})))))
+
 ;; Broken
 (comment (kaocha.repl/run #'test-crdt-array-set-index))
 (deftest test-crdt-array-set-index
+  (let [sys-time-ms (u/str->long "1643061294999")
+        arg {:cmds [{:zeno/arg ["Hi"]
+                     :zeno/op :zeno/set
+                     :zeno/path [:zeno/crdt]}
+                    {:zeno/arg "Bob"
+                     :zeno/op :zeno/set
+                     :zeno/path [:zeno/crdt 1]}]
+             :crdt-schema (l/array-schema l/string-schema)
+             :sys-time-ms sys-time-ms}
+        {:keys [crdt ops]} (commands/process-cmds arg)
+        expected-value ["Hi" "Bob"]]
+    (is (= expected-value (crdt/get-value {:crdt crdt
+                                           :path []
+                                           :schema (:crdt-schema arg)})))))
+
+;; Broken
+(comment (kaocha.repl/run #'test-crdt-array-set-index-into-empty))
+(deftest test-crdt-array-set-into-empty
   (let [sys-time-ms (u/str->long "1643061294999")
         arg {:cmds [{:zeno/arg "Hi"
                      :zeno/op :zeno/set
@@ -707,7 +740,8 @@
                                   :path []
                                   :schema (:crdt-schema arg)})))))
 
-(comment (kaocha.repl/run #'test-set-nested-arrays-at-once))
+(comment (kaocha.repl/run #'test-set-nested-arrays-at-once
+                          {:capture-output? false}))
 (deftest test-set-nested-arrays-at-once
   (let [sys-time-ms (u/str->long "1643061294782")
         value [[1 2] [3]]


### PR DESCRIPTION
This fixes and adds tests for using nested arrays. The issue was that they weren't being properly nested in the crdt data structure. You can see the resulting change in the data structure in the below example. Also I found that setting arrays by index doesn't work and added a few broken tests for that, I haven't yet figured out all the details but I have one lead.

```clojure
;;; Before, note that while the :children section reflects the nesting the :add-id-to-edge map has lost that information. Thus -START- has two children and -END- two parents.
{:add-id-to-edge {"7teg4ba37gk569vdcz2w6p6hjm" {:head-node-id "-START-"
                                                :tail-node-id "c4mtqsn66mje48ad3nxvdmgm3h"}
                  "9e6ysh7mxjjxjan9gvk990m9fr" {:head-node-id "-START-"
                                                :tail-node-id "62vemx4n3ahtsacnybwydd06kq"}
                  "c3ah8jt6hgjwram6fps3xvkxkv" {:head-node-id "c4mtqsn66mje48ad3nxvdmgm3h"
                                                :tail-node-id "-END-"}
                  "d6jn0zefxgh339gpr21s69tewq" {:head-node-id "62vemx4n3ahtsacnybwydd06kq"
                                                :tail-node-id "-END-"}}
 :children {"c4mtqsn66mje48ad3nxvdmgm3h"
            {:children {"62vemx4n3ahtsacnybwydd06kq"
                        {:current-add-id-to-value-info {"54zhce9qxth1aabkx4y72kxsh0"
                                                        {:sys-time-ms 1643061294782
                                                         :value 1}}}}}}
 :current-edge-add-ids #{"7teg4ba37gk569vdcz2w6p6hjm"
                         "9e6ysh7mxjjxjan9gvk990m9fr"
                         "c3ah8jt6hgjwram6fps3xvkxkv"
                         "d6jn0zefxgh339gpr21s69tewq"}}

;;; After, here the second array is nested in :children, a pattern I noticed was the case for nested maps.
{:add-id-to-edge {"7teg4ba37gk569vdcz2w6p6hjm" {:head-node-id "-START-"
                                                :tail-node-id "c4mtqsn66mje48ad3nxvdmgm3h"}
                  "c3ah8jt6hgjwram6fps3xvkxkv" {:head-node-id "c4mtqsn66mje48ad3nxvdmgm3h"
                                                :tail-node-id "-END-"}}
 :children {"c4mtqsn66mje48ad3nxvdmgm3h"
            {:add-id-to-edge {"9e6ysh7mxjjxjan9gvk990m9fr" {:head-node-id "-START-"
                                                            :tail-node-id "62vemx4n3ahtsacnybwydd06kq"}
                              "d6jn0zefxgh339gpr21s69tewq" {:head-node-id "62vemx4n3ahtsacnybwydd06kq"
                                                            :tail-node-id "-END-"}}
             :children {"62vemx4n3ahtsacnybwydd06kq"
                        {:current-add-id-to-value-info {"54zhce9qxth1aabkx4y72kxsh0"
                                                        {:sys-time-ms 1643061294782
                                                         :value 1}}}}
             :current-edge-add-ids #{"9e6ysh7mxjjxjan9gvk990m9fr"
                                     "d6jn0zefxgh339gpr21s69tewq"}}}
 :current-edge-add-ids #{"7teg4ba37gk569vdcz2w6p6hjm"
                         "c3ah8jt6hgjwram6fps3xvkxkv"}}

```