### PR TITLE
Authenticator branches

### DIFF
--- a/src/com/oncurrent/zeno/authenticators/password/server.clj
+++ b/src/com/oncurrent/zeno/authenticators/password/server.clj
@@ -47,7 +47,7 @@
               (fn [old-state]
                 (when (:actor-id old-state)
                   (throw (ex-info
-                          (str"Actor `" actor-id "` already exists")
+                          (str "Actor `" actor-id "` already exists")
                           {})))
                 (assoc old-state actor-id
                        (bcrypt/encrypt password work-factor)))))

--- a/src/com/oncurrent/zeno/authenticators/password/server.clj
+++ b/src/com/oncurrent/zeno/authenticators/password/server.clj
@@ -17,23 +17,14 @@
 
 (set! *warn-on-reflection* true)
 
-(def actor-id-to-hashed-password-key-prefix "_ACTOR-ID-TO-HASHED-PASSWORD-")
 (def work-factor 12)
 
-(defn <get-hashed-password-for-actor-id [authenticator-storage actor-id]
-  (let [k (str actor-id-to-hashed-password-key-prefix actor-id)]
-    (storage/<get authenticator-storage k l/string-schema)))
-
 (defn <log-in!*
-  [{:keys [authenticator-branch
-           authenticator-storage
-           login-lifetime-mins
-           login-info]}]
+  [{:keys [<get-authenticator-state login-lifetime-mins login-info]}]
   (au/go
     (let [{:keys [actor-id password]} login-info
-          hashed-password (when actor-id
-                            (au/<? (<get-hashed-password-for-actor-id
-                                    authenticator-storage actor-id)))]
+          authenticator-state (au/<? (<get-authenticator-state))
+          hashed-password (get authenticator-state actor-id)]
       (when (and hashed-password
                  (bcrypt/check password hashed-password))
         ;; Can also return `:extra-info`, but we don't have any
@@ -45,43 +36,41 @@
     true))
 
 (defmulti <update-authenticator-state!* :update-type)
-(defmulti <get-authenticator-state* :get-type)
+(defmulti <read-authenticator-state* :get-type)
 
 (defmethod <update-authenticator-state!* :add-actor-and-password
-  [{:keys [authenticator-storage update-info]}]
+  [{:keys [<get-authenticator-state <swap-authenticator-state! update-info]}]
   (au/go
     (let [{:keys [actor-id password]} update-info
-          actor-id (or (:actor-id update-info) (u/compact-random-uuid))
-          sk (str actor-id-to-hashed-password-key-prefix actor-id)
-          pwd-fn (fn [old-hashed-password]
-                   (when old-hashed-password
-                     (throw (ex-info
-                             (str"Actor `" actor-id "` already exists")
-                             {})))
-                   (bcrypt/encrypt password work-factor))]
-      (au/<? (storage/<swap! authenticator-storage sk shared/password-schema
-                             pwd-fn))
+          actor-id (or (:actor-id update-info) (u/compact-random-uuid))]
+      (au/<? (<swap-authenticator-state!
+              (fn [old-state]
+                (when (:actor-id old-state)
+                  (throw (ex-info
+                          (str"Actor `" actor-id "` already exists")
+                          {})))
+                (assoc old-state actor-id
+                       (bcrypt/encrypt password work-factor)))))
       true)))
 
 (defmethod <update-authenticator-state!* :set-password
-  [{:keys [authenticator-storage actor-id update-info]}]
+  [{:keys [<swap-authenticator-state! actor-id update-info]}]
   (au/go
     (when-not actor-id
       (throw (ex-info "Actor is not logged in." {})))
-    (let [{:keys [old-password new-password]} update-info
-          sk (str actor-id-to-hashed-password-key-prefix actor-id)]
-      (au/<? (storage/<swap! authenticator-storage sk l/string-schema
-                             (fn [old-hashed-password]
-                               (when-not
-                                   (bcrypt/check old-password
-                                                 old-hashed-password)
-                                 (throw (ex-info "Old password is incorrect."
-                                                 {})))
-                               (bcrypt/encrypt new-password work-factor))))
+    (let [{:keys [old-password new-password]} update-info]
+      (au/<? (<swap-authenticator-state!
+              (fn [old-state]
+                (when-not
+                  (bcrypt/check old-password (get old-state actor-id))
+                  (throw (ex-info "Old password is incorrect."
+                                  {})))
+                (assoc old-state actor-id
+                       (bcrypt/encrypt new-password work-factor)))))
       true)))
 
 (defrecord PasswordAuthenticator
-    [login-lifetime-mins storage-name]
+    [login-lifetime-mins]
   za/IAuthenticator
   (<log-in! [this arg]
     (<log-in!* (assoc arg :login-lifetime-mins login-lifetime-mins)))
@@ -89,14 +78,16 @@
     (<log-out!* arg))
   (<update-authenticator-state! [this arg]
     (<update-authenticator-state!* arg))
-  (<get-authenticator-state [this arg]
-    (<get-authenticator-state* arg))
+  (<read-authenticator-state [this arg]
+    (<read-authenticator-state* arg))
   (get-login-info-schema [this]
     shared/login-info-schema)
   (get-login-ret-extra-info-schema [this]
     l/null-schema)
   (get-name [this]
     shared/authenticator-name)
+  (get-schema [this]
+    shared/storage-schema)
   (get-update-state-info-schema [this update-type]
     (case update-type
       :add-actor-and-password shared/add-actor-and-password-info-schema
@@ -105,18 +96,14 @@
     (case update-type
       :add-actor-and-password l/boolean-schema
       :set-password l/boolean-schema))
-  (get-get-state-info-schema [this get-type]
+  (get-read-state-info-schema [this get-type]
     )
-  (get-get-state-ret-schema [this get-type]
+  (get-read-state-ret-schema [this get-type]
     ))
 
 (defn ->authenticator
   ([]
    (->authenticator {}))
-  ([{:keys [login-lifetime-mins storage-name]
+  ([{:keys [login-lifetime-mins]
      :or {login-lifetime-mins (* 14 24 60)}}]
-   (when-not (or (nil? storage-name) (keyword? storage-name))
-     (throw (ex-info
-             (str "The supplied storage-name must be a keyword or nil. Got "
-                  storage-name " which is a " (type storage-name) ". "))))
-   (->PasswordAuthenticator login-lifetime-mins storage-name)))
+   (->PasswordAuthenticator login-lifetime-mins)))

--- a/src/com/oncurrent/zeno/authenticators/password/shared.cljc
+++ b/src/com/oncurrent/zeno/authenticators/password/shared.cljc
@@ -7,6 +7,9 @@
 
 (def authenticator-name :com.oncurrent.zeno.authenticators/password)
 (def password-schema l/string-schema)
+(def hashed-password-schema l/string-schema)
+
+(l/def-map-schema storage-schema hashed-password-schema)
 
 (l/def-record-schema add-actor-and-password-info-schema
   [:actor-id schemas/actor-id-schema]

--- a/src/com/oncurrent/zeno/client/authenticator_impl.cljc
+++ b/src/com/oncurrent/zeno/client/authenticator_impl.cljc
@@ -16,19 +16,15 @@
   (on-actor-id-change actor-id))
 
 (defn <client-log-in
-  [{:keys [authenticator-name
-           login-info
-           login-info-schema
-           login-ret-extra-info-schema
-           zeno-client]}]
+  [{:keys [authenticator-name login-info login-info-schema
+           login-ret-extra-info-schema zeno-client]}]
   (au/go
-    (let [{:keys [crdt-branch storage talk2-client]} zeno-client
+    (let [{:keys [env-name storage talk2-client]} zeno-client
           ser-login-info (au/<? (storage/<value->serialized-value
                                  storage
                                  login-info-schema
                                  login-info))
           arg {:authenticator-name authenticator-name
-               :branch crdt-branch
                :serialized-login-info ser-login-info}
           ret (au/<? (t2c/<send-msg! talk2-client :log-in arg))]
       (when ret
@@ -50,12 +46,8 @@
   (t2c/<send-msg! talk2-client :log-out nil))
 
 (defn <client-update-authenticator-state
-  [{:keys [authenticator-name
-           return-value-schema
-           update-info-schema
-           update-info
-           update-type
-           zeno-client]}]
+  [{:keys [authenticator-name return-value-schema update-info-schema
+           update-info update-type zeno-client]}]
   (when-not (keyword? authenticator-name)
     (throw (ex-info (str "`authenticator-name` must be a keyword. Got `"
                          (or authenticator-name "nil") "`.")
@@ -73,12 +65,11 @@
             (u/sym-map authenticator-name update-info-schema update-type
                        update-info))))
   (au/go
-    (let [{:keys [crdt-branch storage talk2-client]} zeno-client
+    (let [{:keys [storage talk2-client]} zeno-client
           ser-info (au/<? (storage/<value->serialized-value storage
                                                             update-info-schema
                                                             update-info))
           arg {:authenticator-name authenticator-name
-               :branch crdt-branch
                :serialized-update-info ser-info
                :update-type update-type}
           s-val (au/<? (t2c/<send-msg! talk2-client
@@ -90,40 +81,35 @@
                :serialized-value s-val
                :storage storage})))))
 
-(defn <client-get-authenticator-state
-  [{:keys [authenticator-name
-           return-value-schema
-           get-info-schema
-           get-info
-           get-type
-           zeno-client]}]
+(defn <client-read-authenticator-state
+  [{:keys [authenticator-name read-info read-info-schema read-type
+           return-value-schema zeno-client]}]
   (when-not (keyword? authenticator-name)
     (throw (ex-info (str "`authenticator-name` must be a keyword. Got `"
                          (or authenticator-name "nil") "`.")
-                    (u/sym-map authenticator-name get-type get-info))))
+                    (u/sym-map authenticator-name read-type read-info))))
   (when-not (l/schema? return-value-schema)
     (throw (ex-info
             (str "`return-value-schema` must be a Lancaster schema. Got `"
                  (or return-value-schema "nil") "`.")
-            (u/sym-map authenticator-name return-value-schema get-type
-                       get-info))))
-  (when-not (l/schema? get-info-schema)
+            (u/sym-map authenticator-name return-value-schema read-type
+                       read-info))))
+  (when-not (l/schema? read-info-schema)
     (throw (ex-info
-            (str "`get-info-schema` must be a Lancaster schema. Got `"
-                 (or get-info-schema "nil") "`.")
-            (u/sym-map authenticator-name get-info-schema get-type
-                       get-info))))
+            (str "`read-info-schema` must be a Lancaster schema. Got `"
+                 (or read-info-schema "nil") "`.")
+            (u/sym-map authenticator-name read-info-schema read-type
+                       read-info))))
   (au/go
-    (let [{:keys [crdt-branch storage talk2-client]} zeno-client
+    (let [{:keys [storage talk2-client]} zeno-client
           ser-info (au/<? (storage/<value->serialized-value storage
-                                                            get-info-schema
-                                                            get-info))
+                                                            read-info-schema
+                                                            read-info))
           arg {:authenticator-name authenticator-name
-               :branch crdt-branch
-               :serialized-get-info ser-info
-               :get-type get-type}
+               :serialized-read-info ser-info
+               :read-type read-type}
           s-val (au/<? (t2c/<send-msg! talk2-client
-                                       :get-authenticator-state
+                                       :read-authenticator-state
                                        arg))]
       (au/<? (common/<serialized-value->value
               {:<request-schema (cimpl/make-schema-requester talk2-client)

--- a/src/com/oncurrent/zeno/schemas.cljc
+++ b/src/com/oncurrent/zeno/schemas.cljc
@@ -130,7 +130,6 @@
 
 (l/def-record-schema log-in-arg-schema
   [:authenticator-name authenticator-name-schema]
-  [:branch branch-schema]
   [:serialized-login-info serialized-value-schema])
 
 (l/def-record-schema log-in-ret-schema
@@ -139,15 +138,13 @@
 
 (l/def-record-schema update-authenticator-state-arg-schema
   [:authenticator-name authenticator-name-schema]
-  [:branch branch-schema]
   [:serialized-update-info serialized-value-schema]
   [:update-type l/keyword-schema])
 
-(l/def-record-schema get-authenticator-state-arg-schema
+(l/def-record-schema read-authenticator-state-arg-schema
   [:authenticator-name authenticator-name-schema]
-  [:branch branch-schema]
-  [:serialized-get-info serialized-value-schema]
-  [:get-type l/keyword-schema])
+  [:serialized-read-info serialized-value-schema]
+  [:read-type l/keyword-schema])
 
 ;;;;;;;;;;;;;;; Envs ;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -218,9 +215,6 @@
                            :ret-schema l/boolean-schema}
    :update-authenticator-state {:arg-schema
                                 update-authenticator-state-arg-schema
-                                :ret-schema
-                                serialized-value-schema}
-   :get-authenticator-state {:arg-schema
-                             get-authenticator-state-arg-schema
-                             :ret-schema
-                             serialized-value-schema}})
+                                :ret-schema serialized-value-schema}
+   :read-authenticator-state {:arg-schema read-authenticator-state-arg-schema
+                             :ret-schema serialized-value-schema}})

--- a/src/com/oncurrent/zeno/schemas.cljc
+++ b/src/com/oncurrent/zeno/schemas.cljc
@@ -14,6 +14,7 @@
 (def client-id-schema l/string-schema)
 (def cluster-member-id-schema l/string-schema)
 (def env-name-schema l/string-schema)
+(def env-lifetime-mins-schema l/long-schema)
 (def fingerprint-schema l/bytes-schema)
 (def login-session-token-schema l/string-schema)
 (def node-id-schema l/string-schema)
@@ -149,13 +150,15 @@
 ;;;;;;;;;;;;;;; Envs ;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (l/def-record-schema stored-authenticator-info-schema
+  [:authenticator-name authenticator-name-schema]
   [:authenticator-branch branch-schema]
-  [:authenticator-name authenticator-name-schema])
+  [:authenticator-branch-source branch-schema])
 
 (l/def-record-schema stored-state-provider-info-schema
   [:path-root l/keyword-schema]
+  [:state-provider-name state-provider-name-schema]
   [:state-provider-branch branch-schema]
-  [:state-provider-name state-provider-name-schema])
+  [:state-provider-branch-source branch-schema])
 
 (l/def-record-schema stored-env-info-schema
   [:env-name env-name-schema]

--- a/src/com/oncurrent/zeno/server/authenticator_impl.clj
+++ b/src/com/oncurrent/zeno/server/authenticator_impl.clj
@@ -288,7 +288,7 @@
            <swap!* (make-<swap-authenticator-state!
                     (assoc arg :authenticator-branch authenticator-branch))
            src-state (au/<? (<get*))]
-       (log/info "AM COPYING")
+       (log/info "COPYING")
        (au/<?
         (<swap!*
          (fn [old-state]

--- a/src/com/oncurrent/zeno/server/authenticator_impl.clj
+++ b/src/com/oncurrent/zeno/server/authenticator_impl.clj
@@ -288,7 +288,6 @@
            <swap!* (make-<swap-authenticator-state!
                     (assoc arg :authenticator-branch authenticator-branch))
            src-state (au/<? (<get*))]
-       (log/info "COPYING")
        (au/<?
         (<swap!*
          (fn [old-state]

--- a/src/com/oncurrent/zeno/server/authenticator_impl.clj
+++ b/src/com/oncurrent/zeno/server/authenticator_impl.clj
@@ -17,41 +17,55 @@
   (<log-in! [this arg])
   (<log-out! [this arg])
   (<update-authenticator-state! [this arg])
-  (<get-authenticator-state [this arg])
+  (<read-authenticator-state [this arg])
   (get-login-info-schema [this])
   (get-login-ret-extra-info-schema [this])
   (get-name [this])
+  (get-schema [this])
   (get-update-state-info-schema [this update-type])
   (get-update-state-ret-schema [this update-type])
-  (get-get-state-info-schema [this get-type])
-  (get-get-state-ret-schema [this get-type]))
+  (get-read-state-info-schema [this read-type])
+  (get-read-state-ret-schema [this read-type]))
 
 (defn generate-login-session-token []
   (ba/byte-array->b64 (su/secure-random-bytes 32)))
 
+(defn branch->key [branch]
+  (str "_" branch))
+
+(defn make-<get-authenticator-state
+  [{:keys [authenticator authenticator-storage authenticator-branch branch]}]
+  (fn []
+    (storage/<get authenticator-storage
+                  (branch->key (or branch authenticator-branch))
+                  (get-schema authenticator))))
+
+(defn make-<swap-authenticator-state!
+  [{:keys [authenticator authenticator-storage authenticator-branch branch]}]
+  (fn [update-fn]
+    (storage/<swap! authenticator-storage
+                    (branch->key (or branch authenticator-branch))
+                    (get-schema authenticator)
+                    update-fn)))
+
 (defn <handle-log-in
-  [{:keys [*conn-id->auth-info
-           *connected-actor-id->conn-ids
-           <get-state
-           <set-state!
-           <update-state!
-           env-authenticator-name->info
-           conn-id
-           env-name
-           storage]
-    :as arg}]
+  [{:keys [*conn-id->auth-info *connected-actor-id->conn-ids
+           <get-state <set-state! <update-state!
+           arg env-authenticator-name->info conn-id env-name storage]
+    :as fn-arg}]
   (au/go
-    (let [{:keys [authenticator-name serialized-login-info]} (:arg arg)
+    (let [{:keys [authenticator-name serialized-login-info]} arg
           auth-info (env-authenticator-name->info authenticator-name)
           _ (when-not auth-info
               (throw (ex-info
                       (str "No authenticator with name `" authenticator-name
                            "` was found in this env.")
                       (u/sym-map authenticator-name env-name))))
+          <get-authenticator-state (make-<get-authenticator-state auth-info)
           {:keys [authenticator
                   authenticator-branch
                   authenticator-storage]} auth-info
-          <request-schema (su/make-schema-requester arg)
+          <request-schema (su/make-schema-requester fn-arg)
           reader-schema (get-login-info-schema authenticator)
           login-info (au/<? (common/<serialized-value->value
                              {:<request-schema <request-schema
@@ -59,11 +73,10 @@
                               :serialized-value serialized-login-info
                               :storage storage}))
           login-ret (au/<? (<log-in! authenticator
-                                     (u/sym-map <get-state
+                                     (u/sym-map <get-authenticator-state
+                                                <get-state
                                                 <set-state!
                                                 <update-state!
-                                                authenticator-branch
-                                                authenticator-storage
                                                 login-info)))]
       (when login-ret
         (let [{:keys [extra-info login-lifetime-mins actor-id]} login-ret
@@ -110,7 +123,8 @@
                                 (assoc :authenticator authenticator)
                                 (assoc :authenticator-storage
                                        authenticator-storage)
-                                (assoc :branch (:branch arg))
+                                (assoc :authenticator-branch
+                                       authenticator-branch)
                                 (assoc :login-session-token
                                        login-session-token)
                                 (assoc :actor-id actor-id)))))
@@ -126,24 +140,22 @@
   (au/go
     (let [auth-info (some-> @*conn-id->auth-info
                             (get conn-id))
+          <get-authenticator-state (make-<get-authenticator-state auth-info)
           token-k (str storage/login-session-token-to-token-info-key-prefix
                        (:login-session-token auth-info))]
       (au/<? (storage/<delete! storage token-k))
       (au/<? (<log-out! (:authenticator auth-info)
-                        (merge {:authenticator-storage
-                                (:authenticator-storage auth-info)}
-                               (u/sym-map <get-state
-                                          <set-state!
-                                          <update-state!)))))))
+                        (u/sym-map <get-authenticator-state
+                                   <get-state
+                                   <set-state!
+                                   <update-state!))))))
 
 (defn <handle-resume-login-session
-  [{:keys [*conn-id->auth-info
-           *connected-actor-id->conn-ids
-           conn-id
-           storage]
-    :as arg}]
+  [{:keys [*conn-id->auth-info *connected-actor-id->conn-ids
+           arg conn-id storage]
+    :as fn-arg}]
   (au/go
-    (let [login-session-token (:arg arg)
+    (let [login-session-token arg
           token-k (str storage/login-session-token-to-token-info-key-prefix
                        login-session-token)
           info (au/<? (storage/<get storage
@@ -177,25 +189,27 @@
           nil)))))
 
 (defn <handle-update-authenticator-state
-  [{:keys [*conn-id->auth-info <get-state <set-state! <update-state!
+  [{:keys [*conn-id->auth-info arg <get-state <set-state! <update-state!
            env-authenticator-name->info env-name conn-id storage]
-    :as arg}]
+    :as fn-arg}]
   ;; Client may or may not be logged in when this is called
   (au/go
     (let [{:keys [authenticator-name
                   serialized-update-info
-                  update-type]} (:arg arg)
+                  update-type]} arg
           auth-info (env-authenticator-name->info authenticator-name)
           _ (when-not auth-info
               (throw (ex-info
                       (str "No authenticator with name `" authenticator-name
                            "` was found in this env.")
                       (u/sym-map authenticator-name env-name))))
+          <get-authenticator-state (make-<get-authenticator-state auth-info)
+          <swap-authenticator-state! (make-<swap-authenticator-state! auth-info)
           {:keys [authenticator
                   authenticator-branch
                   authenticator-storage]} auth-info
           reader-schema (get-update-state-info-schema authenticator update-type)
-          <request-schema (su/make-schema-requester arg)
+          <request-schema (su/make-schema-requester fn-arg)
           update-info (au/<? (common/<serialized-value->value
                               {:<request-schema <request-schema
                                :reader-schema reader-schema
@@ -205,11 +219,11 @@
                                      (get conn-id))
           ret (au/<? (<update-authenticator-state!
                       authenticator
-                      (u/sym-map <get-state
+                      (u/sym-map <get-authenticator-state
+                                 <swap-authenticator-state!
+                                 <get-state
                                  <set-state!
                                  <update-state!
-                                 authenticator-branch
-                                 authenticator-storage
                                  actor-id
                                  update-info
                                  update-type)))]
@@ -218,44 +232,44 @@
               (get-update-state-ret-schema authenticator update-type)
               ret)))))
 
-(defn <handle-get-authenticator-state
+(defn <handle-read-authenticator-state
   [{:keys [*conn-id->auth-info <get-state <set-state! <update-state!
-           env-authenticator-name->info conn-id storage]
-    :as arg}]
+           arg env-authenticator-name->info conn-id storage]
+    :as fn-arg}]
   ;; Client may or may not be logged in when this is called)
   (au/go
     (let [{:keys [authenticator-name
-                  serialized-get-info
-                  get-type]} (:arg arg)
+                  serialized-read-info
+                  read-type]} arg
           auth-info (env-authenticator-name->info authenticator-name)
           _ (when-not auth-info
               (throw (ex-info
                       (str "No authenticator with name `" authenticator-name
                            "` was found.")
                       (u/sym-map authenticator-name))))
+          <get-authenticator-state (make-<get-authenticator-state auth-info)
           {:keys [authenticator
                   authenticator-branch
                   authenticator-storage]} auth-info
-          reader-schema (get-get-state-info-schema authenticator get-type)
-          <request-schema (su/make-schema-requester arg)
-          get-info (au/<? (common/<serialized-value->value
+          reader-schema (get-read-state-info-schema authenticator read-type)
+          <request-schema (su/make-schema-requester fn-arg)
+          read-info (au/<? (common/<serialized-value->value
                            {:<request-schema <request-schema
                             :reader-schema reader-schema
-                            :serialized-value serialized-get-info
+                            :serialized-value serialized-read-info
                             :storage storage}))
           {:keys [actor-id]} (some-> @*conn-id->auth-info
                                      (get conn-id))
-          ret (au/<? (<get-authenticator-state
+          ret (au/<? (<read-authenticator-state
                       authenticator
-                      (u/sym-map <get-state
+                      (u/sym-map <get-authenticator-state
+                                 <get-state
                                  <set-state!
                                  <update-state!
-                                 authenticator-branch
-                                 authenticator-storage
                                  actor-id
-                                 get-info
-                                 get-type)))]
+                                 read-info
+                                 read-type)))]
       (au/<? (storage/<value->serialized-value
               storage
-              (get-get-state-ret-schema authenticator get-type)
+              (get-read-state-ret-schema authenticator read-type)
               ret)))))

--- a/test/integration/authentication_test.cljc
+++ b/test/integration/authentication_test.cljc
@@ -14,7 +14,7 @@
    [taoensso.timbre :as log]
    [test-common :as c]))
 
-(comment (kaocha.repl/run 'integration.authentication-test))
+(comment (kaocha.repl/run *ns*))
 
 ;;;; IMPORTANT!!!
 ;;;; You must start the integration test server for these tests to work.

--- a/test/integration/env_test.cljc
+++ b/test/integration/env_test.cljc
@@ -142,27 +142,35 @@
           _ (au/<? (<add-actor-password! actor2 password2 zc-perm))
           zc-temp (c/->zc {:source-env-name perm})
           _ (au/<? (<add-actor-password! actor3 password3 zc-temp))]
+
       (au/<? (<test-log-in-out! actor1 password1 zc-base true))
       (au/<? (<test-log-in-out! actor1 password1 zc-perm true))
       (au/<? (<test-log-in-out! actor1 password1 zc-temp true))
+
       (au/<? (<test-log-in-out! actor2 password2 zc-base false))
       (au/<? (<test-log-in-out! actor2 password2 zc-perm true))
       (au/<? (<test-log-in-out! actor2 password2 zc-temp true))
+
       (au/<? (<test-log-in-out! actor3 password3 zc-base false))
       (au/<? (<test-log-in-out! actor3 password3 zc-perm false))
       (au/<? (<test-log-in-out! actor3 password3 zc-temp true))
+
       (au/<? (<add-actor-password! actor4 password4 zc-base))
       (au/<? (<add-actor-password! actor5 password5 zc-perm))
       (au/<? (<add-actor-password! actor6 password6 zc-temp))
+
       (au/<? (<test-log-in-out! actor4 password4 zc-base true))
       (au/<? (<test-log-in-out! actor4 password4 zc-perm false))
       (au/<? (<test-log-in-out! actor4 password4 zc-temp false))
+
       (au/<? (<test-log-in-out! actor5 password5 zc-base false))
       (au/<? (<test-log-in-out! actor5 password5 zc-perm true))
       (au/<? (<test-log-in-out! actor5 password5 zc-temp false))
+
       (au/<? (<test-log-in-out! actor6 password6 zc-base false))
       (au/<? (<test-log-in-out! actor6 password6 zc-perm false))
       (au/<? (<test-log-in-out! actor6 password6 zc-temp true))
+
       (zc/stop! zc-base)
       (zc/stop! zc-perm)
       (zc/stop! zc-temp)))))

--- a/test/integration/env_test.cljc
+++ b/test/integration/env_test.cljc
@@ -26,11 +26,11 @@
   (au/test-async
    5000
    (au/go
+    (au/<? (c/<clear-envs!))
      (let [admin (admin/->admin-client
                   #:zeno{:admin-password c/admin-password
                          :get-server-base-url
                          (constantly "ws://localhost:8080/admin")})
-           _ (au/<? (c/<clear-envs! admin))
            ;; Create a permanent env to use as a base
            perm-env-name (u/compact-random-uuid)
            auth-infos [#:zeno{:authenticator-name
@@ -100,8 +100,7 @@
        (zc/stop! zc-temp)))))
 
 (comment
- (kaocha.repl/run #'test-envs-authenticator-copy
-                  {:capture-output? false}))
+ (kaocha.repl/run #'test-envs-authenticator-copy {:capture-output? false}))
 (deftest test-envs-authenticator-copy
   (au/test-async
    10000
@@ -115,55 +114,55 @@
           [actor4 password4] ["actor4" "password4"]
           [actor5 password5] ["actor5" "password5"]
           [actor6 password6] ["actor6" "password6"]
+          <add-actor-password! (fn [a p zc]
+                                 (au/go
+                                  (is (= true
+                                         (au/<?
+                                          (pwd-client/<add-actor-and-password!
+                                           {:zeno/actor-id a
+                                            ::pwd-auth/password p
+                                            :zeno/zeno-client zc}))))))
+          <test-log-in-out! (fn [a p zc should-work?]
+                              (au/go
+                               (is (= should-work?
+                                      (boolean
+                                       (au/<? (pwd-client/<log-in!
+                                               {:zeno/actor-id a
+                                                ::pwd-auth/password p
+                                                :zeno/zeno-client zc})))))
+                               (is (= true (au/<? (pwd-client/<log-out!
+                                                   {:zeno/zeno-client zc}))))))
           _ (is (= true (au/<? (c/<setup-env! {:env-name base}))))
           zc-base (c/->zc {:env-name base})
-          _ (is (= true (au/<? (pwd-client/<add-actor-and-password!
-                                {:zeno/actor-id actor1
-                                 ::pwd-auth/password password1
-                                 :zeno/zeno-client zc-base}))))
+          _ (au/<? (<add-actor-password! actor1 password1 zc-base))
           _ (is (= true (au/<? (c/<setup-env!
                                 {:env-name perm
                                  :authenticator-branch-source base}))))
           zc-perm (c/->zc {:env-name perm})
-          _ (is (= true (au/<? (pwd-client/<add-actor-and-password!
-                                {:zeno/actor-id actor2
-                                 ::pwd-auth/password password2
-                                 :zeno/zeno-client zc-perm}))))
+          _ (au/<? (<add-actor-password! actor2 password2 zc-perm))
           zc-temp (c/->zc {:source-env-name perm})
-          _ (is (= true (au/<? (pwd-client/<add-actor-and-password!
-                                {:zeno/actor-id actor3
-                                 ::pwd-auth/password password3
-                                 :zeno/zeno-client zc-temp}))))
-          ;; login true 1 on zc-base
-          ;; login true 1 on zc-perm
-          ;; login true 1 on zc-temp
-          ;; login fail 2 on zc-base
-          ;; login true 2 on zc-perm
-          ;; login true 2 on zc-temp
-          ;; login fail 3 on zc-base
-          ;; login fail 3 on zc-perm
-          ;; login true 3 on zc-temp
-          ;; add 4 to zc-base
-          ;; add 5 to zc-perm
-          ;; add 6 to zc-temp
-          ;; login true 4 on zc-base
-          ;; login fail 4 on zc-perm
-          ;; login fail 4 on zc-temp
-          ;; login fail 5 on zc-base
-          ;; login true 5 on zc-perm
-          ;; login fail 5 on zc-temp
-          ;; login 6 fail on zc-base
-          ;; login 6 fail on zc-perm
-          ;; login 6 true on zc-temp
-
-          login-ret (au/<? (pwd-client/<log-in!
-                            {::pwd-auth/password password
-                             :zeno/actor-id actor-id
-                             :zeno/zeno-client zc-perm}))
-          _ (is (not= false login-ret))
-          _ (is (= true (au/<? (pwd-client/<log-out!
-                                {:zeno/zeno-client zc-perm}))))
-          ]
+          _ (au/<? (<add-actor-password! actor3 password3 zc-temp))]
+      (au/<? (<test-log-in-out! actor1 password1 zc-base true))
+      (au/<? (<test-log-in-out! actor1 password1 zc-perm true))
+      (au/<? (<test-log-in-out! actor1 password1 zc-temp true))
+      (au/<? (<test-log-in-out! actor2 password2 zc-base false))
+      (au/<? (<test-log-in-out! actor2 password2 zc-perm true))
+      (au/<? (<test-log-in-out! actor2 password2 zc-temp true))
+      (au/<? (<test-log-in-out! actor3 password3 zc-base false))
+      (au/<? (<test-log-in-out! actor3 password3 zc-perm false))
+      (au/<? (<test-log-in-out! actor3 password3 zc-temp true))
+      (au/<? (<add-actor-password! actor4 password4 zc-base))
+      (au/<? (<add-actor-password! actor5 password5 zc-perm))
+      (au/<? (<add-actor-password! actor6 password6 zc-temp))
+      (au/<? (<test-log-in-out! actor4 password4 zc-base true))
+      (au/<? (<test-log-in-out! actor4 password4 zc-perm false))
+      (au/<? (<test-log-in-out! actor4 password4 zc-temp false))
+      (au/<? (<test-log-in-out! actor5 password5 zc-base false))
+      (au/<? (<test-log-in-out! actor5 password5 zc-perm true))
+      (au/<? (<test-log-in-out! actor5 password5 zc-temp false))
+      (au/<? (<test-log-in-out! actor6 password6 zc-base false))
+      (au/<? (<test-log-in-out! actor6 password6 zc-perm false))
+      (au/<? (<test-log-in-out! actor6 password6 zc-temp true))
       (zc/stop! zc-base)
       (zc/stop! zc-perm)
       (zc/stop! zc-temp)))))

--- a/test/integration/env_test.cljc
+++ b/test/integration/env_test.cljc
@@ -20,10 +20,11 @@
 ;;;; You must start the integration test server for these tests to work.
 ;;;; $ bin/run-test-server
 
-(comment (kaocha.repl/run *ns* {:color? false}))
+(comment
+ (kaocha.repl/run *ns* {:color? false}))
 (deftest test-envs
   (au/test-async
-   10000
+   5000
    (au/go
      (let [admin (admin/->admin-client
                   #:zeno{:admin-password c/admin-password
@@ -47,8 +48,8 @@
                                         :authenticator-infos auth-infos
                                         :env-name perm-env-name
                                         :state-provider-infos spis}))))
-           envs* (au/<? (admin/<get-env-names {:zeno/admin-client admin}))
-           _ (is (= [perm-env-name] envs*))
+           envs (au/<? (admin/<get-env-names {:zeno/admin-client admin}))
+           _ (is (= [perm-env-name] envs))
            ;; Connect to the permanent env and set some state
            zc-perm (c/->zc {:env-name perm-env-name})
            sub-map {'name [:zeno/crdt :name]}
@@ -60,7 +61,8 @@
                                           :zeno/path [:zeno/crdt :name]}]))
            _ (is (= '{name "base"} (get-state zc-perm)))
            ;; Connect to a temp env based on the permanent env
-           zc-temp (c/->zc {:source-env-name perm-env-name})
+           zc-temp (c/->zc {:source-env-name perm-env-name
+                            :env-lifetime-mins 1})
            ;; Verify that the `:name` is "base"
            _ (is (= '{name "base"} (get-state zc-temp)))
            ;; Set the `:name` to "temp" in this env

--- a/test/test_common.cljc
+++ b/test/test_common.cljc
@@ -77,20 +77,22 @@
 
 (defn <setup-env! [{:keys [env-name]}]
   (au/go
-    (let [admin (admin/->admin-client
-                 #:zeno{:admin-password admin-password
-                        :get-server-base-url
-                        (constantly "ws://localhost:8080/admin")})
-          envs (au/<? (admin/<get-env-names {:zeno/admin-client admin}))
-          _ (when (= true (some #(= env-name %) envs))
-              (au/<? (admin/<delete-env!
-                      #:zeno{:admin-client admin
-                             :env-name env-name})))
-          auth-infos [#:zeno{:authenticator-name pwd-shared/authenticator-name}]]
-      (au/<? (admin/<create-env!
-              #:zeno{:admin-client admin
-                     :authenticator-infos auth-infos
-                     :env-name env-name})))))
+   (let [admin (admin/->admin-client
+                #:zeno{:admin-password admin-password
+                       :get-server-base-url
+                       (constantly "ws://localhost:8080/admin")})
+         envs (au/<? (admin/<get-env-names {:zeno/admin-client admin}))
+         _ (when (= true (some #(= env-name %) envs))
+             (au/<? (admin/<delete-env!
+                     #:zeno{:admin-client admin
+                            :env-name env-name})))
+         auth-infos [#:zeno{:authenticator-name pwd-shared/authenticator-name}]
+         ret (au/<? (admin/<create-env!
+                     #:zeno{:admin-client admin
+                            :authenticator-infos auth-infos
+                            :env-name env-name}))]
+      (admin/stop! admin)
+      ret)))
 
 (defn <clear-envs! [admin]
   (au/go

--- a/test/test_common.cljc
+++ b/test/test_common.cljc
@@ -2,6 +2,7 @@
   (:require
    [clojure.core.async :as ca]
    [clojure.string :as str]
+   [clojure.test :refer [deftest is]]
    [deercreeklabs.async-utils :as au]
    [deercreeklabs.lancaster :as l]
    [com.oncurrent.zeno.admin-client :as admin]
@@ -13,6 +14,12 @@
    [com.oncurrent.zeno.state-providers.crdt.client :as crdt-client]
    [com.oncurrent.zeno.utils :as u]
    [taoensso.timbre :as log]))
+
+(def ex #?(:clj Exception :cljs js/Error))
+
+(defn catcher [e]
+  (log/error (u/ex-msg-and-stacktrace e))
+  (is (= :threw :but-should-not-have)))
 
 (def admin-password (str "hYczFGGPRFkKGK3yQxDGz7imUbDXAE8iRtUs.tfvAYqsVbeTQN"
                          "jbYwHB_skGw!ft4yMDrMD@uxwe@9an-iqa2ZYr3cAtmGt2MW_i"))


### PR DESCRIPTION
You can now specify `authenticator-branch-source` in your environment's authenticator. Temp branches do this for you as well. Copying from one branch to the other is eager. Authenticators deal in blobs now via the `<get-authenticator-state` and `<swap-authenticator-state!` functions provided to them on the server side. Application RPC's can construct these two functions as well in order to call authenticator server functions directly.