### PR TITLE
expand paths on server side

### DIFF
--- a/src/com/oncurrent/zeno/client/state_subscriptions.cljc
+++ b/src/com/oncurrent/zeno/client/state_subscriptions.cljc
@@ -208,10 +208,11 @@
                                     :state state
                                     :zc zc})
 
-                    :zeno/concat {:path path*
-                                  :root root
-                                  :state state
-                                  :zc zc})]
+                    :zeno/concat
+                    (do-concat {:path path*
+                                :root root
+                                :state state
+                                :zc zc}))]
         [value [path*]])
 
       (and (not terminal-kw?) join?)

--- a/src/com/oncurrent/zeno/state_providers/crdt/server.clj
+++ b/src/com/oncurrent/zeno/state_providers/crdt/server.clj
@@ -188,9 +188,10 @@
         *storage (atom nil)
         <get-state (fn [{:zeno/keys [branch path]}]
                      (au/go
-                       (common/get-value
+                       (common/get-value-info
                         {:crdt (get @*branch->crdt-store branch)
                          :path path
+                         :norm-path []
                          :schema schema})))
         <update-state! (fn [{:zeno/keys [branch cmds] :as us-arg}]
                          (au/go

--- a/test/integration/rpc_test.cljc
+++ b/test/integration/rpc_test.cljc
@@ -14,8 +14,8 @@
 ;;;; You must start the integration test server for these tests to work.
 ;;;; $ bin/run-test-server
 
-(comment (kaocha.repl/run *ns*))
-
+(comment
+ (kaocha.repl/run *ns*))
 (deftest test-rpc
   (au/test-async
    10000

--- a/test/unit/crdt_commands_test.cljc
+++ b/test/unit/crdt_commands_test.cljc
@@ -1157,28 +1157,6 @@
                                            :path []
                                            :schema (:schema arg)})))))
 
-(comment
- (krun #'test-get-join))
-(deftest test-get-join
-  (let [value {:pet-owners {"steve-id" {:name "steve"
-                                        :pets [{:name "p1"
-                                                :species "s1"}
-                                               {:name "p2"
-                                                :species "s2"}]}
-                            "bob-id" {:name "bob"
-                                      :pets [{:name "p3"
-                                              :species "s3"}]}}}
-        arg {:cmds [{:zeno/arg value
-                     :zeno/op :zeno/set
-                     :zeno/path [:zeno/crdt]}]
-             :root :zeno/crdt
-             :schema pet-school-schema}
-        {:keys [crdt]} (commands/process-cmds arg)
-        expected-value (get-in value [:pet-owners "steve-id"])]
-    (is (= expected-value (crdt/get-value {:crdt crdt
-                                           :path [:pet-owners ["steve-id"]]
-                                           :schema (:schema arg)})))))
-
 ;; BROKEN
 (comment (krun #'test-get-empty-array))
 (deftest test-get-empty-array

--- a/test/unit/crdt_commands_test.cljc
+++ b/test/unit/crdt_commands_test.cljc
@@ -49,6 +49,7 @@
   [:specialties specialties-schema])
 
 (l/def-map-schema pet-owners-schema pet-owner-schema)
+
 (l/def-record-schema pet-school-schema
   [:pet-owners (l/map-schema pet-owner-schema)])
 
@@ -1155,3 +1156,40 @@
     (is (= expected-value (crdt/get-value {:crdt crdt
                                            :path []
                                            :schema (:schema arg)})))))
+
+(comment
+ (krun #'test-get-join))
+(deftest test-get-join
+  (let [value {:pet-owners {"steve-id" {:name "steve"
+                                        :pets [{:name "p1"
+                                                :species "s1"}
+                                               {:name "p2"
+                                                :species "s2"}]}
+                            "bob-id" {:name "bob"
+                                      :pets [{:name "p3"
+                                              :species "s3"}]}}}
+        arg {:cmds [{:zeno/arg value
+                     :zeno/op :zeno/set
+                     :zeno/path [:zeno/crdt]}]
+             :root :zeno/crdt
+             :schema pet-school-schema}
+        {:keys [crdt]} (commands/process-cmds arg)
+        expected-value (get-in value [:pet-owners "steve-id"])]
+    (is (= expected-value (crdt/get-value {:crdt crdt
+                                           :path [:pet-owners ["steve-id"]]
+                                           :schema (:schema arg)})))))
+
+;; BROKEN
+(comment (krun #'test-get-empty-array))
+(deftest test-get-empty-array
+  (let [value {:pet-owners {"bob-id" {:name "bob"
+                                      :pets []}}}
+        arg {:cmds [{:zeno/arg value
+                     :zeno/op :zeno/set
+                     :zeno/path [:zeno/crdt]}]
+             :root :zeno/crdt
+             :schema pet-school-schema}
+        {:keys [crdt]} (commands/process-cmds arg)]
+    (is (= value (crdt/get-value {:crdt crdt
+                                  :path []
+                                  :schema (:schema arg)})))))


### PR DESCRIPTION
Tests are passing. My bug in Oncurrent is resolved.

I saw that Vivo took this approach of largely copy/paste between the client/server. There are different patterns on each side, perhaps we could unify them perhaps not.

I also added a broken test I discovered, perhaps it causes the CRDT anomaly where the data doesn't match before and after.