### PR TITLE
client creates temp env name

### DIFF
--- a/src/com/oncurrent/zeno/client/impl.cljc
+++ b/src/com/oncurrent/zeno/client/impl.cljc
@@ -146,9 +146,7 @@
 (defn make-get-url [{:keys [get-server-base-url] :as arg}]
   (fn []
     (let [base-url (get-server-base-url)
-          ks [:env-name :source-env-name :env-lifetime-mins]
-          query-str (u/map->query-string {:ks ks
-                                          :m arg})]
+          query-str (u/env-params->query-string arg)]
       (str base-url
            (when-not (str/ends-with? base-url "/")
              "/")
@@ -276,7 +274,8 @@
   (ca/put! (:update-state-ch zc) (u/sym-map cmds cb)))
 
 (defn zeno-client [config]
-  (let [config* (merge default-config config)
+  (let [config* (-> (merge default-config config)
+                    (u/fill-env-defaults "zeno"))
         _ (u/check-config {:config config*
                            :config-type :client
                            :config-rules client-config-rules})

--- a/src/com/oncurrent/zeno/client/impl.cljc
+++ b/src/com/oncurrent/zeno/client/impl.cljc
@@ -275,7 +275,7 @@
 
 (defn zeno-client [config]
   (let [config* (-> (merge default-config config)
-                    (u/fill-env-defaults "zeno"))
+                    (u/fill-env-defaults))
         _ (u/check-config {:config config*
                            :config-type :client
                            :config-rules client-config-rules})

--- a/src/com/oncurrent/zeno/server.clj
+++ b/src/com/oncurrent/zeno/server.clj
@@ -748,6 +748,11 @@
         (let [uri-map (uri/uri path)
               env-params (-> uri-map :query u/query-string->env-params)
               {:keys [env-name]} env-params]
+          (when-not env-name
+            (throw (ex-info
+                    (str "Must provide an :env-name in order to connect. "
+                         "Got `" (or env-name "nil") "`.")
+                    env-params)))
           (when-not (contains? @*env-name->info env-name)
             ;; Create a temp env
             (swap! *env-name->info

--- a/src/com/oncurrent/zeno/utils.cljc
+++ b/src/com/oncurrent/zeno/utils.cljc
@@ -480,29 +480,24 @@
             (recur)))))
     (sym-map now! stop!)))
 
-(defn fill-env-defaults
-  ([m]
-   (fill-env-defaults m nil))
-  ([m ns*]
-   (letfn [(kw [s] (keyword ns* s))]
-     (-> m
-         (update (kw "env-name") #(cond
-                                   (not-empty %) %
-                                   (or (not-empty ((kw "source-env-name") m))
-                                       ((kw "env-lifetime-mins") m))
-                                   (compact-random-uuid)
-                                   :else default-env-name))
-         (update (kw "source-env-name") #(if (not-empty %) % default-env-name))
-         (update (kw "env-lifetime-mins") #(or % default-env-lifetime-mins))))))
+(defn fill-env-defaults [m]
+  (-> m
+      (update :zeno/env-name #(cond
+                               (not-empty %) %
+                               (or (not-empty (:zeno/source-env-name m))
+                                   (:zeno/env-lifetime-mins m))
+                               (compact-random-uuid)
+                               :else default-env-name))
+      (update :zeno/source-env-name #(if (not-empty %) % default-env-name))
+      (update :zeno/env-lifetime-mins #(or % default-env-lifetime-mins))))
 
 (defn env-params->query-string [m]
   (map->query-string {:ks [:env-name :source-env-name :env-lifetime-mins]
-                      :m (fill-env-defaults m)}))
+                      :m m}))
 
 (defn query-string->env-params [s]
   (-> (query-string->map s)
-      (update :env-lifetime-mins str->int)
-      (fill-env-defaults)))
+      (update :env-lifetime-mins str->int)))
 
 ;;;;;;;;;;;;;;;;;;;; Platform detection ;;;;;;;;;;;;;;;;;;;;
 

--- a/test/unit/utils_test.cljc
+++ b/test/unit/utils_test.cljc
@@ -101,24 +101,20 @@
  (kaocha.repl/run #'test-fill-env-defaults {:color? false}))
 (deftest test-fill-env-defaults
   (let [f u/fill-env-defaults]
-    (is (= {:env-name u/default-env-name
-            :source-env-name u/default-env-name
-            :env-lifetime-mins u/default-env-lifetime-mins}
-           (f {})))
     (is (= #:zeno{:env-name u/default-env-name
                   :source-env-name u/default-env-name
                   :env-lifetime-mins u/default-env-lifetime-mins}
-           (f {} "zeno")))
-    (is (= {:env-name "nacho"
-            :source-env-name u/default-env-name
-            :env-lifetime-mins 1}
-           (f {:env-name "nacho"
-               :env-lifetime-mins 1})))
-    (let [ret (f {:source-env-name "nacho"})]
-      (is (= "nacho" (:source-env-name ret)))
-      (is (= u/default-env-lifetime-mins (:env-lifetime-mins ret)))
-      (is (= 26 (count (:env-name ret)))))
-    (let [ret (f {:env-lifetime-mins 1})]
-      (is (= u/default-env-name (:source-env-name ret)))
-      (is (= 1 (:env-lifetime-mins ret)))
-      (is (= 26 (count (:env-name ret)))))))
+           (f {})))
+    (is (= #:zeno{:env-name "nacho"
+                  :source-env-name u/default-env-name
+                  :env-lifetime-mins 1}
+           (f #:zeno{:env-name "nacho"
+                     :env-lifetime-mins 1})))
+    (let [ret (f #:zeno{:source-env-name "nacho"})]
+      (is (= "nacho" (:zeno/source-env-name ret)))
+      (is (= u/default-env-lifetime-mins (:zeno/env-lifetime-mins ret)))
+      (is (= 26 (count (:zeno/env-name ret)))))
+    (let [ret (f #:zeno{:env-lifetime-mins 1})]
+      (is (= u/default-env-name (:zeno/source-env-name ret)))
+      (is (= 1 (:zeno/env-lifetime-mins ret)))
+      (is (= 26 (count (:zeno/env-name ret)))))))

--- a/test/unit/utils_test.cljc
+++ b/test/unit/utils_test.cljc
@@ -4,6 +4,7 @@
    [clojure.test :as t :refer [deftest is are]]
    [deercreeklabs.async-utils :as au]
    [com.oncurrent.zeno.utils :as u]
+   #?(:clj [kaocha.repl])
    [taoensso.timbre :as log]))
 
 (deftest test-sub-map->map-info
@@ -88,10 +89,36 @@
     (catch #?(:clj Exception :cljs js/Error) e
       (is (= :unexpected e)))))
 
-(deftest chop-root
+(deftest test-chop-root
   (let [f u/chop-root]
     (is (= [] (f [] nil)))
     (is (= [] (f [:zeno/crdt] :zeno/crdt)))
     (is (= [:pigs] (f [:zeno/crdt :pigs] :zeno/crdt)))
     (is (= [:zeno/crdt :pigs] (f [:zeno/crdt :pigs] :pigs)))
     (is (= [:pigs] (f [:zeno/crdt :zeno/crdt :zeno/crdt :pigs] :zeno/crdt)))))
+
+(comment
+ (kaocha.repl/run #'test-fill-env-defaults {:color? false}))
+(deftest test-fill-env-defaults
+  (let [f u/fill-env-defaults]
+    (is (= {:env-name u/default-env-name
+            :source-env-name u/default-env-name
+            :env-lifetime-mins u/default-env-lifetime-mins}
+           (f {})))
+    (is (= #:zeno{:env-name u/default-env-name
+                  :source-env-name u/default-env-name
+                  :env-lifetime-mins u/default-env-lifetime-mins}
+           (f {} "zeno")))
+    (is (= {:env-name "nacho"
+            :source-env-name u/default-env-name
+            :env-lifetime-mins 1}
+           (f {:env-name "nacho"
+               :env-lifetime-mins 1})))
+    (let [ret (f {:source-env-name "nacho"})]
+      (is (= "nacho" (:source-env-name ret)))
+      (is (= u/default-env-lifetime-mins (:env-lifetime-mins ret)))
+      (is (= 26 (count (:env-name ret)))))
+    (let [ret (f {:env-lifetime-mins 1})]
+      (is (= u/default-env-name (:source-env-name ret)))
+      (is (= 1 (:env-lifetime-mins ret)))
+      (is (= 26 (count (:env-name ret)))))))


### PR DESCRIPTION
My intent is to just have the client call fill-env-defaults (which creates an env-name if temp) and have the server just expect all three fields to be appropriately set. I'm not sure how aggressively to throw on the server side though.